### PR TITLE
Bump version of finagle-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
       <plugin>
         <groupId>com.twitter</groupId>
         <artifactId>maven-finagle-thrift-plugin</artifactId>
-        <version>0.0.7</version>
+        <version>0.0.9</version>
         <configuration>
           <thriftGenerators>
             <thriftGenerator>java</thriftGenerator>


### PR DESCRIPTION
Bump version of maven-finagle-thrift-plugin as one step to partially address broken build reported in issue #8
