### PR TITLE
Make advertised server host address configurable

### DIFF
--- a/config/development.scala
+++ b/config/development.scala
@@ -6,9 +6,10 @@ import java.net.InetAddress
 import com.twitter.ostrich.admin.config.AdminServiceConfig
 
 new SnowflakeConfig {
+  publishAddress = InetAddress.getLocalHost
   serverPort = 7609
   datacenterId = 0
-  workerIdMap = Map(0 -> InetAddress.getLocalHost.getHostName)
+  workerIdMap = Map(0 -> publishAddress.getHostName)
   workerIdZkPath = "/snowflake-servers"
   skipSanityChecks = false
   startupSleepMs = 10000

--- a/config/development2.scala
+++ b/config/development2.scala
@@ -6,9 +6,10 @@ import java.net.InetAddress
 import com.twitter.ostrich.admin.config.AdminServiceConfig
 
 new SnowflakeConfig {
+  publishAddress = InetAddress.getLocalHost
   serverPort = 7610
   datacenterId = 0
-  workerIdMap = Map(1 -> InetAddress.getLocalHost.getHostName)
+  workerIdMap = Map(1 -> publishAddress.getHostName)
   workerIdZkPath = "/snowflake-servers"
   skipSanityChecks = false
   startupSleepMs = 10000

--- a/config/test.scala
+++ b/config/test.scala
@@ -4,9 +4,10 @@ import java.net.InetAddress
 import com.twitter.ostrich.admin.config.AdminServiceConfig
 
 new SnowflakeConfig {
+  publishAddress = InetAddress.getLocalHost
   serverPort = 7609
   datacenterId = 0
-  workerIdMap = Map(0 -> InetAddress.getLocalHost.getHostName)
+  workerIdMap = Map(0 -> publishAddress.getHostName)
   workerIdZkPath = "/snowflake-servers"
   skipSanityChecks = false
   startupSleepMs = 10000

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>service-292</artifactId>
-    <version>0.0.4</version>
+    <version>0.0.12</version>
   </parent>
   <properties>
     <git.dir>${project.basedir}/../.git</git.dir>
@@ -75,13 +75,24 @@
       <artifactId>util-thrift</artifactId>
       <version>5.3.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.scala-tools.testing</groupId>
+      <artifactId>specs_2.9.3</artifactId>
+      <version>1.6.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency> 
+      <groupId>junit</groupId> 
+      <artifactId>junit</artifactId> 
+      <version>4.5</version> 
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <groupId>com.twitter</groupId>
         <artifactId>maven-finagle-thrift-plugin</artifactId>
-        <version>0.0.7</version>
+        <version>0.0.9</version>
         <configuration>
           <thriftGenerators>
             <thriftGenerator>java</thriftGenerator>

--- a/src/main/scala/com/twitter/service/snowflake/SnowflakeConfig.scala
+++ b/src/main/scala/com/twitter/service/snowflake/SnowflakeConfig.scala
@@ -8,6 +8,7 @@ import com.twitter.zookeeper.ZookeeperClientConfig
 import com.twitter.util.Config.RequiredValuesMissing
 
 trait SnowflakeConfig extends ServerConfig[SnowflakeServer] {
+  var publishAddress = InetAddress.getLocalHost
   var serverPort = 7609
   var datacenterId = required[Int]
   var workerIdMap = required[Map[Int, String]]
@@ -29,8 +30,9 @@ trait SnowflakeConfig extends ServerConfig[SnowflakeServer] {
   }
 
   def apply(runtime: RuntimeEnvironment) = {
-    new SnowflakeServer(serverPort, datacenterId, workerIdFor(InetAddress.getLocalHost),
-        workerIdZkPath, skipSanityChecks, startupSleepMs, thriftServerThreads, reporterConfig(),
+    new SnowflakeServer(publishAddress, serverPort, datacenterId,
+        workerIdFor(publishAddress), workerIdZkPath, skipSanityChecks,
+        startupSleepMs, thriftServerThreads, reporterConfig(),
         zookeeperClientConfig())
   }
 
@@ -38,7 +40,7 @@ trait SnowflakeConfig extends ServerConfig[SnowflakeServer] {
     if (workerIdMap.values.size != workerIdMap.values.toSet.size)
       throw new RequiredValuesMissing("duplicate worker Ids")
     zookeeperClientConfig.validate
-    reporterConfig.validate 
+    reporterConfig.validate
     super.validate
   }
 }


### PR DESCRIPTION
This change allows to configure the server host address that will be advertised within ZooKeeper. This allows for running Snowflake within VMs or Docker containers that don't have an IP address that is directly accessible by other Snowflake servers in other VMs/containers.

It also merges in the `updated_deps` branch, which allows for the branch to compile out of the box.
